### PR TITLE
show position in native currency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 data
 .env
-test
+test.py
 notes.md
 __pycache__
 trading


### PR DESCRIPTION
get position now defaults to showing positions in native currency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> get_positions now defaults to native (market) currency and adds pagination, aggregation, and optional security details.
> 
> - **API (wealthsimple_v2.py)**:
>   - **get_positions**:
>     - Defaults `currency` to None and applies `currencyOverride: 'MARKET'` (native currency).
>     - Adds params: `include_security`, `first`, `aggregated`.
>     - Expands GraphQL: pagination (`first`, `cursor`, `pageInfo`), `aggregated`, `currencyOverride`, and richer fields (marketAveragePrice, marketBookValue, marketUnrealizedReturns, status, totalCount); conditional inclusion of security details and quotes.
>     - Updates variables accordingly and returns position nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 909ef6b8ac8d34e13f990c4cf2c41bbb38c692cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->