### PR TITLE
Add market metadata, chart quotes, and account graph APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 - Security search by ticker symbol or company name
 - Real-time quotes with bid/ask spreads
 - Detailed security information (fundamentals, market status)
-- Market metadata and market buffer lookups
+- Nearest market open and market buffer lookups
 - Intraday chart quotes from Wealthsimple's native chart API
 - Support for stocks across multiple exchanges (NASDAQ, NYSE, TSX, etc.)
 - **WebSocket subscriptions for real-time streaming data**
@@ -332,14 +332,14 @@ print(f"Market Cap: ${fundamentals.get('marketCap')}")
 print(f"Dividend Yield: {fundamentals.get('dividendYield')}%")
 ```
 
-#### Get Market Metadata
+#### Get Nearest Market Open
 
 ```python
-# Get supported market metadata
-markets = ws.get_markets_metadata()
+# Get previous/current/next market session boundaries
+market_open = ws.get_nearest_market_open()
 
-for market in markets:
-    print(f"{market['exchangeName']} ({market['mic']}): open={market['open']}, close={market['close']}")
+print(f"Exchange: {market_open['exchangeName']} ({market_open['mic']})")
+print(f"Current trade day: {market_open['currentTradeDay']['date']}")
 ```
 
 #### Get Market Buffer
@@ -1337,7 +1337,7 @@ ws = WealthsimpleV2(
 | `search_securities(query, security_group_ids=None)` | Search for securities by ticker or name |
 | `get_security(security_id, currency=None)`          | Get detailed security information       |
 | `get_security_quote(security_id, currency=None)`    | Get real-time quote                     |
-| `get_markets_metadata()`                            | Get supported market metadata           |
+| `get_nearest_market_open()`                         | Get nearest market open details         |
 | `get_market_buffer(country='CA', is_option=False)`  | Get the market buffer multiplier        |
 | `get_security_status(security_id)`                  | Get security trading status             |
 | `get_intraday_chart_quotes(...)`                    | Get broker-native intraday chart quotes |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@
 - Security search by ticker symbol or company name
 - Real-time quotes with bid/ask spreads
 - Detailed security information (fundamentals, market status)
+- Market metadata and market buffer lookups
+- Intraday chart quotes from Wealthsimple's native chart API
 - Support for stocks across multiple exchanges (NASDAQ, NYSE, TSX, etc.)
 - **WebSocket subscriptions for real-time streaming data**
   - Real-time security quote updates
@@ -70,6 +72,7 @@
 
 - Retrieve all accounts (Personal, TFSA, RRSP, etc.)
 - Account balances and buying power
+- Current account financials and broker-native graph data
 - Current positions with unrealized P/L
 - Activity feed and order history
 - **Daily historical portfolio financials** with automatic pagination
@@ -329,6 +332,57 @@ print(f"Market Cap: ${fundamentals.get('marketCap')}")
 print(f"Dividend Yield: {fundamentals.get('dividendYield')}%")
 ```
 
+#### Get Market Metadata
+
+```python
+# Get supported market metadata
+markets = ws.get_markets_metadata()
+
+for market in markets:
+    print(f"{market['exchangeName']} ({market['mic']}): open={market['open']}, close={market['close']}")
+```
+
+#### Get Market Buffer
+
+```python
+# Get the current market buffer for a country / asset class
+buffer = ws.get_market_buffer(country='CA', is_option=False)
+print(f"Market buffer: {buffer}")
+```
+
+#### Get Security Status
+
+```python
+# Check trading status for a security
+status = ws.get_security_status(security_id)
+print(f"Security status: {status['status']}")
+```
+
+#### Get Intraday Chart Quotes
+
+```python
+# Get Wealthsimple-native chart points
+bars = ws.get_intraday_chart_quotes(
+    security_id=security_id,
+    period='ONE_DAY',
+    trading_session='REGULAR'
+)
+
+for bar in bars:
+    print(f"{bar['timestamp']}: {bar['price']}")
+```
+
+#### Resolve Ticker Market Symbols
+
+```python
+# Convert ticker.market symbols into Wealthsimple security IDs
+symbol, market = ws.parse_ticker_market('TSLA.US')
+print(symbol, market)
+
+security_id = ws.resolve_security_id('MFC.TO')
+print(f"Security ID: {security_id}")
+```
+
 ### Account Management
 
 #### Get All Accounts
@@ -389,6 +443,32 @@ for position in positions:
 # Get positions for specific accounts
 account_ids = [accounts[0]['id']]  # Only first account
 positions = ws.get_positions(account_ids=account_ids)
+```
+
+#### Get Current Financials
+
+```python
+# Get current metrics for a single account
+current = ws.get_account_current_financials(account_id)
+
+print(f"Net liquidation value: {current['netLiquidationValueV2']['amount']}")
+print(f"Net deposits: {current['netDeposits']['amount']}")
+print(f"Total withdrawals: {current['totalWithdrawals']['amount']}")
+```
+
+#### Get Account Graph Data
+
+```python
+# Get broker-native graph data for charting
+graph = ws.get_account_graph_data(
+    account_id=account_id,
+    currency='CAD',
+    time_range='ONE_DAY',
+    market_session='REGULAR'
+)
+
+for point in graph.get('data', []):
+    print(f"{point['dateTime']}: {point['netLiquidationValue']['amount']}")
 ```
 
 ### Stock Trading
@@ -1257,7 +1337,15 @@ ws = WealthsimpleV2(
 | `search_securities(query, security_group_ids=None)` | Search for securities by ticker or name |
 | `get_security(security_id, currency=None)`          | Get detailed security information       |
 | `get_security_quote(security_id, currency=None)`    | Get real-time quote                     |
+| `get_markets_metadata()`                            | Get supported market metadata           |
+| `get_market_buffer(country='CA', is_option=False)`  | Get the market buffer multiplier        |
+| `get_security_status(security_id)`                  | Get security trading status             |
+| `get_intraday_chart_quotes(...)`                    | Get broker-native intraday chart quotes |
 | `get_ticker_id(ticker, exchange=None)`              | Get security ID from ticker symbol      |
+| `parse_ticker_market(ticker_market)`                | Split `TICKER.MARKET` into parts        |
+| `_is_us_exchange(exchange)`                         | Check whether an exchange is US-listed  |
+| `_is_canadian_exchange(exchange)`                   | Check whether an exchange is CA-listed  |
+| `resolve_security_id(ticker_market)`                | Resolve `TICKER.MARKET` to a security ID |
 
 #### Account Methods
 
@@ -1265,6 +1353,8 @@ ws = WealthsimpleV2(
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
 | `get_accounts(identity_id=None)`                                                                                                                            | Get all accounts                          |
 | `get_account_financials(account_ids, currency='CAD')`                                                                                                       | Get account balances                      |
+| `get_account_current_financials(account_id, currency='CAD', start_date=None)`                                                                              | Get current account financials            |
+| `get_account_graph_data(account_id, currency='CAD', time_range='ONE_DAY', market_session='REGULAR', include_simple_returns=False)`                        | Get account graph data                    |
 | `get_positions(identity_id=None, account_ids=None, security_types=None)`                                                                                    | Get current positions                     |
 | `get_activities(account_ids=None, types=None, limit=50)`                                                                                                    | Get activity feed                         |
 | `get_identity(identity_id=None)`                                                                                                                            | Get user identity information             |

--- a/wealthsimple_v2.py
+++ b/wealthsimple_v2.py
@@ -596,33 +596,98 @@ class WealthsimpleV2:
         result = self.graphql_query("FetchSecuritySearchResult", gql_query, variables)
         return result.get('data', {}).get('securitySearch', {}).get('results', [])
 
-    def get_markets_metadata(self) -> List[Dict]:
+    def get_nearest_market_open(self) -> Dict:
         """
-        Get metadata for all supported markets (NASDAQ, NYSE, TSX, etc.).
+        Get the nearest market open payload used by the current web app.
         
         Returns:
-            List of market metadata dictionaries
+            Dictionary containing exchange info and previous/current/next trade days
         """
         gql_query = """
-        query FetchMarketsMetadata {
-          marketsMetadata {
-            cacheDate
-            close
-            date
+        query FetchNearestMarketOpen {
+          nearestMarketOpen {
+            currentTradeDay {
+              date
+              overnight {
+                start
+                end
+                __typename
+              }
+              preMarket {
+                start
+                end
+                __typename
+              }
+              regular {
+                start
+                end
+                __typename
+              }
+              postMarket {
+                start
+                end
+                __typename
+              }
+              __typename
+            }
             exchangeName
-            lastOpenDate
-            lastOpenTime
+            isTodayEarlyClose
             mic
-            nextOpenDate
-            nextOpenTime
-            open
+            nextTradeDay {
+              date
+              overnight {
+                start
+                end
+                __typename
+              }
+              preMarket {
+                start
+                end
+                __typename
+              }
+              regular {
+                start
+                end
+                __typename
+              }
+              postMarket {
+                start
+                end
+                __typename
+              }
+              __typename
+            }
+            previousTradeDay {
+              date
+              overnight {
+                start
+                end
+                __typename
+              }
+              preMarket {
+                start
+                end
+                __typename
+              }
+              regular {
+                start
+                end
+                __typename
+              }
+              postMarket {
+                start
+                end
+                __typename
+              }
+              __typename
+            }
             __typename
           }
         }
         """
         
-        result = self.graphql_query("FetchMarketsMetadata", gql_query, {})
-        return result.get('data', {}).get('marketsMetadata', [])
+        result = self.graphql_query("FetchNearestMarketOpen", gql_query, {})
+        return result.get('data', {}).get('nearestMarketOpen', {})
 
     def get_market_buffer(self, country: str = 'CA', is_option: bool = False) -> float:
         """
@@ -3124,4 +3189,3 @@ if __name__ == "__main__":
         print("  export WS_USERNAME='your@email.com'")
         print("  export WS_PASSWORD='yourpassword'")
         print("  export WS_OTP='123456'  # Optional, only if 2FA enabled")
-

--- a/wealthsimple_v2.py
+++ b/wealthsimple_v2.py
@@ -595,6 +595,63 @@ class WealthsimpleV2:
         
         result = self.graphql_query("FetchSecuritySearchResult", gql_query, variables)
         return result.get('data', {}).get('securitySearch', {}).get('results', [])
+
+    def get_markets_metadata(self) -> List[Dict]:
+        """
+        Get metadata for all supported markets (NASDAQ, NYSE, TSX, etc.).
+        
+        Returns:
+            List of market metadata dictionaries
+        """
+        gql_query = """
+        query FetchMarketsMetadata {
+          marketsMetadata {
+            cacheDate
+            close
+            date
+            exchangeName
+            lastOpenDate
+            lastOpenTime
+            mic
+            nextOpenDate
+            nextOpenTime
+            open
+            __typename
+          }
+        }
+        """
+        
+        result = self.graphql_query("FetchMarketsMetadata", gql_query, {})
+        return result.get('data', {}).get('marketsMetadata', [])
+
+    def get_market_buffer(self, country: str = 'CA', is_option: bool = False) -> float:
+        """
+        Get the market buffer multiplier for a country/asset type.
+        
+        Args:
+            country: Two-letter country code ('CA' or 'US')
+            is_option: Whether the buffer is for an option
+            
+        Returns:
+            Market buffer as a float (e.g., 1.006)
+        """
+        gql_query = """
+        query FetchMarketBuffer($country: String!, $isOption: Boolean) {
+          marketBuffer(country: $country, isOption: $isOption) {
+            marketBuffer
+            __typename
+          }
+        }
+        """
+        
+        variables = {
+            "country": country,
+            "isOption": is_option
+        }
+        
+        result = self.graphql_query("FetchMarketBuffer", gql_query, variables)
+        buffer_str = result.get('data', {}).get('marketBuffer', {}).get('marketBuffer')
+        return float(buffer_str) if buffer_str else 1.05 # Default to safe 5% if missing
     
     def get_security(self, security_id: str, currency: Optional[str] = None) -> Dict:
         """
@@ -764,6 +821,133 @@ class WealthsimpleV2:
         
         result = self.graphql_query("FetchSecurityQuoteV2", gql_query, variables)
         return result.get('data', {}).get('security', {}).get('quoteV2', {})
+
+    def get_security_status(self, security_id: str) -> Dict:
+        """
+        Get the trading status of a security.
+        
+        Args:
+            security_id: The security ID
+            
+        Returns:
+            Dictionary containing security status
+        """
+        gql_query = """
+        query FetchSecurityStatus($id: ID!) {
+          security(id: $id) {
+            id
+            status
+            optionDetails {
+              underlyingSecurity {
+                id
+                status
+              }
+            }
+            __typename
+          }
+        }
+        """
+        
+        variables = {"id": security_id}
+        result = self.graphql_query("FetchSecurityStatus", gql_query, variables)
+        return result.get('data', {}).get('security', {})
+
+    def get_intraday_chart_quotes(
+        self,
+        security_id: str,
+        period: str = 'ONE_DAY',
+        trading_session: Optional[str] = 'REGULAR',
+        currency: Optional[str] = None,
+        date: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Get Wealthsimple-native chart bar quotes for a security.
+
+        Args:
+            security_id: Security ID
+            period: Chart period (e.g. ONE_DAY, ONE_WEEK, ONE_MONTH)
+            trading_session: Trading session (e.g. REGULAR, OVERNIGHT)
+            currency: Optional quote currency
+            date: Optional date in YYYY-MM-DD format for date-scoped requests
+
+        Returns:
+            List of chart bar quote dictionaries
+        """
+        if trading_session is not None:
+            gql_query = """
+            query FetchIntraDayChartQuotes(
+              $id: ID!,
+              $date: Date,
+              $tradingSession: TradingSession,
+              $currency: Currency,
+              $period: ChartPeriod
+            ) {
+              security(id: $id) {
+                id
+                chartBarQuotes(
+                  date: $date
+                  tradingSession: $tradingSession
+                  currency: $currency
+                  period: $period
+                ) {
+                  securityId
+                  price
+                  sessionPrice
+                  timestamp
+                  currency
+                  marketStatus
+                  __typename
+                }
+                __typename
+              }
+            }
+            """
+            variables = {
+                "id": security_id,
+                "date": date,
+                "tradingSession": trading_session,
+                "currency": currency,
+                "period": period,
+            }
+        else:
+            gql_query = """
+            query FetchIntraDayChartQuotes(
+              $id: ID!,
+              $date: Date,
+              $currency: Currency,
+              $period: ChartPeriod
+            ) {
+              security(id: $id) {
+                id
+                chartBarQuotes(
+                  date: $date
+                  currency: $currency
+                  period: $period
+                ) {
+                  securityId
+                  price
+                  sessionPrice
+                  timestamp
+                  currency
+                  marketStatus
+                  __typename
+                }
+                __typename
+              }
+            }
+            """
+            variables = {
+                "id": security_id,
+                "date": date,
+                "currency": currency,
+                "period": period,
+            }
+        
+        # Remove None values so GraphQL doesn't receive explicit nulls for optional Enums
+        variables = {k: v for k, v in variables.items() if v is not None}
+
+        result = self.graphql_query("FetchIntraDayChartQuotes", gql_query, variables)
+        return result.get('data', {}).get('security', {}).get('chartBarQuotes', [])
     
     def get_ticker_id(self, ticker: str, exchange: Optional[str] = None) -> Optional[str]:
         """
@@ -784,6 +968,101 @@ class WealthsimpleV2:
                 if exchange is None or stock.get('primaryExchange') == exchange:
                     return result.get('id')
         
+        return None
+
+    def parse_ticker_market(self, ticker_market: str) -> tuple:
+        """
+        Parse a ticker with market suffix into (symbol, market).
+
+        Args:
+            ticker_market: Ticker with market suffix (e.g., 'TSLA.US', 'MFC.TO')
+
+        Returns:
+            Tuple of (symbol, market) - market is 'US', 'TO', etc.
+        """
+        if '.' in ticker_market:
+            parts = ticker_market.rsplit('.', 1)
+            return parts[0].upper(), parts[1].upper()
+        return ticker_market.upper(), None
+
+    def _is_us_exchange(self, exchange: str) -> bool:
+        """Check if exchange is a US exchange."""
+        if not exchange:
+            return False
+        exchange_upper = exchange.upper()
+        us_exchanges = {'NYSE', 'NASDAQ', 'AMEX', 'BATS', 'XNYS', 'XNAS', 'XASE'}
+        return exchange_upper in us_exchanges
+
+    def _is_canadian_exchange(self, exchange: str) -> bool:
+        """Check if exchange is a Canadian exchange."""
+        if not exchange:
+            return False
+        exchange_upper = exchange.upper()
+        ca_exchanges = {'TSX', 'TSXV', 'CSE', 'NEOE', 'XTSE', 'XTSX', 'XCSE'}
+        return exchange_upper in ca_exchanges
+
+    def resolve_security_id(self, ticker_market: str) -> Optional[str]:
+        """
+        Resolve a ticker with market suffix to its Wealthsimple security ID.
+
+        This method handles the mapping from EODHD-style ticker format (TICKER.MARKET)
+        to Wealthsimple security IDs by searching and filtering results.
+
+        Args:
+            ticker_market: Ticker with market suffix (e.g., 'TSLA.US', 'MFC.TO')
+
+        Returns:
+            Security ID string or None if not found
+        """
+        # Check cache first
+        if hasattr(self, '_security_id_cache') and ticker_market in self._security_id_cache:
+            return self._security_id_cache[ticker_market]
+
+        symbol, market = self.parse_ticker_market(ticker_market)
+
+        results = self.search_securities(symbol)
+        if not results:
+            return None
+
+        # Filter based on market
+        if market == 'US':
+            # For US market, find first US-listed security with matching symbol
+            for result in results:
+                stock = result.get('stock') or {}
+                if stock.get('symbol') == symbol:
+                    exchange = stock.get('primaryExchange', '') or ''
+                    if self._is_us_exchange(exchange):
+                        security_id = result.get('id')
+                        # Cache the result
+                        if not hasattr(self, '_security_id_cache'):
+                            self._security_id_cache = {}
+                        self._security_id_cache[ticker_market] = security_id
+                        return security_id
+        elif market == 'TO':
+            # For Toronto (TSX), find Canadian-listed security
+            for result in results:
+                stock = result.get('stock') or {}
+                if stock.get('symbol') == symbol:
+                    exchange = stock.get('primaryExchange', '') or ''
+                    if self._is_canadian_exchange(exchange):
+                        security_id = result.get('id')
+                        # Cache the result
+                        if not hasattr(self, '_security_id_cache'):
+                            self._security_id_cache = {}
+                        self._security_id_cache[ticker_market] = security_id
+                        return security_id
+        else:
+            # No market specified or unknown market - fall back to first match
+            for result in results:
+                stock = result.get('stock') or {}
+                if stock.get('symbol') == symbol:
+                    security_id = result.get('id')
+                    # Cache the result
+                    if not hasattr(self, '_security_id_cache'):
+                        self._security_id_cache = {}
+                    self._security_id_cache[ticker_market] = security_id
+                    return security_id
+
         return None
     
     # ==================== Options Trading ====================
@@ -1264,6 +1543,173 @@ class WealthsimpleV2:
         
         result = self.graphql_query("FetchAccountFinancials", gql_query, variables)
         return result.get('data', {}).get('accounts', [])
+    
+    def get_account_current_financials(self, account_id: str, currency: str = 'CAD', 
+                                      start_date: Optional[str] = None) -> Dict:
+        """
+        Get current financial metrics for a specific account.
+        
+        Args:
+            account_id: The account ID
+            currency: Currency for the metrics
+            start_date: Reference date for simple returns calculation (YYYY-MM-DD)
+            
+        Returns:
+            Account financials dictionary
+        """
+        gql_query = """
+        query FetchAccountCurrentFinancials($id: ID!, $currency: Currency, $startDate: Date) {
+          account(id: $id) {
+            id
+            financials {
+              current(currency: $currency) {
+                id
+                netLiquidationValueV2 {
+                  amount
+                  cents
+                  currency
+                }
+                netDeposits: netDepositsV2 {
+                  amount
+                  cents
+                  currency
+                }
+                simpleReturns(referenceDate: $startDate) {
+                  amount {
+                    amount
+                    cents
+                    currency
+                  }
+                  asOf
+                  rate
+                  referenceDate
+                }
+                totalDeposits: totalDepositsV2 {
+                  amount
+                  cents
+                  currency
+                }
+                totalWithdrawals: totalWithdrawalsV2 {
+                  amount
+                  cents
+                  currency
+                }
+                __typename
+              }
+              __typename
+            }
+            __typename
+          }
+        }
+        """
+        
+        variables = {
+            "id": account_id,
+            "currency": currency,
+            "startDate": start_date
+        }
+        
+        # Remove None values
+        variables = {k: v for k, v in variables.items() if v is not None}
+        
+        result = self.graphql_query("FetchAccountCurrentFinancials", gql_query, variables)
+        return result.get('data', {}).get('account', {}).get('financials', {}).get('current', {})
+    
+    def get_account_graph_data(
+        self,
+        account_id: str,
+        currency: str = 'CAD',
+        time_range: str = 'ONE_DAY',
+        market_session: str = 'REGULAR',
+        include_simple_returns: bool = False,
+    ) -> Dict:
+        """
+        Get account graph data for an account.
+
+        Args:
+            account_id: Account ID
+            currency: Currency for graph values
+            time_range: Graph time range (e.g. ONE_DAY, ONE_WEEK, ONE_MONTH)
+            market_session: Graph market session (e.g. REGULAR, OVERNIGHT)
+            include_simple_returns: Include simple return payloads in graph points
+
+        Returns:
+            Account graph data dictionary with previousClose and data points
+        """
+        gql_query = """
+        query FetchAccountGraphData(
+          $id: ID!,
+          $currency: Currency!,
+          $timeRange: GraphTimeRange!,
+          $marketSession: GraphMarketSession!,
+          $includeSimpleReturns: Boolean = false
+        ) {
+          account(id: $id) {
+            id
+            financials {
+              currentCombined(currency: $currency) {
+                id
+                graphData(timeRange: $timeRange, marketSession: $marketSession) {
+                  previousClose {
+                    dateTime
+                    netLiquidationValue {
+                      amount
+                      currency
+                      __typename
+                    }
+                    __typename
+                  }
+                  data {
+                    dateTime
+                    netLiquidationValue {
+                      amount
+                      currency
+                      __typename
+                    }
+                    netDeposits {
+                      amount
+                      currency
+                      __typename
+                    }
+                    simpleReturns @include(if: $includeSimpleReturns) {
+                      amount {
+                        amount
+                        currency
+                        __typename
+                      }
+                      rate
+                      referenceDateTime
+                      __typename
+                    }
+                    __typename
+                  }
+                  __typename
+                }
+                __typename
+              }
+              __typename
+            }
+            __typename
+          }
+        }
+        """
+
+        variables = {
+            "id": account_id,
+            "currency": currency,
+            "timeRange": time_range,
+            "marketSession": market_session,
+            "includeSimpleReturns": include_simple_returns,
+        }
+
+        result = self.graphql_query("FetchAccountGraphData", gql_query, variables)
+        current = (
+            result.get('data', {})
+            .get('account', {})
+            .get('financials', {})
+            .get('currentCombined', {})
+        )
+        return current.get('graphData', {})
     
     def get_identity_historical_financials(self, identity_id: Optional[str] = None, currency: str = 'CAD',
                                            start_date: Optional[str] = None, end_date: Optional[str] = None,


### PR DESCRIPTION
This PR adds a few helpful of Wealthsimple calls I’ve been using in a side project for the last couple months, pulled from browser network traffic and wired into the main client. The helper methods were needed to make them usable from normal ticker input. The main value here is that it fills in a few obvious gaps on the read side without changing auth or order flow.


**New functions**:
- `get_markets_metadata()`
  Exchange-level metadata like open/close times and MIC codes
- `get_market_buffer(country, is_option)`
  Returns the market buffer multiplier Wealthsimple uses
- `get_security_status(security_id)`
  Returns the current trading status for a security
- `get_intraday_chart_quotes(...)`
  Returns Wealthsimple-native chart points with timestamps
- `get_account_current_financials(account_id)`
  Returns current account-level liquidation value, deposits, withdrawals, and returns.
- `get_account_graph_data(...)`
  Returns the account graph payload used for charting.
- `parse_ticker_market()`, `_is_us_exchange()`, `_is_canadian_exchange()`, `resolve_security_id()`
  Small glue helpers for inputs like `TSLA.US` and `WCP.TO`
  Parsing the ticker market and market checking were specific to my needs, so not sure if they would be helpful to others.


**Overview**:

`get_intraday_chart_quotes()` exposes Wealthsimple's own chart data instead of forcing callers to infer timing from quote snapshots or rely entirely on external feeds.

`get_account_graph_data()` and `get_account_current_financials()` do the same thing on the account side. Before this, the client had balances and historical financials, but not the broker native graph payload or a clean current financials read for a single account.

`get_security_status()` gives an explicit status check instead of guessing from quote data.

The ticker helpers are boring but necessary. If the caller has `TICKER.MARKET` input, they should not have to reimplement symbol parsing and exchange filtering outside the client.

The return values are plain  dict/list/scalar values. `resolve_security_id()` caches hits after the first lookup, and saves an API call (note: spamming the WealthSimple API endpoint with a request every 30 seconds will give you 429s...) I left `__typename` in the payloads, stripping it would just add cleanup code for no real gain.

README was updated with the new calls.

## Example shapes
Since this PR is adding several new features, I've added below some example outputs from the functions just as a reference.

`ws.get_markets_metadata()`

```python
[
  {
    "__typename": "MarketMetadata",
    "cacheDate": "2026-03-13",
    "close": "16:00:00",
    "date": "2026-03-13",
    "exchangeName": "NASDAQ",
    "lastOpenDate": "2026-03-12",
    "lastOpenTime": "09:30:00",
    "mic": "XNAS",
    "nextOpenDate": "2026-03-16",
    "nextOpenTime": "09:30:00",
    "open": "09:30:00"
  }
]
```

`ws.get_market_buffer(country="CA")`

```python
1.006
```

`ws.get_security_status("sec-s-6e73535b8e474d8689064c4c9fee326a")`

```python
{
  "__typename": "Security",
  "id": "sec-s-6e73535b8e474d8689064c4c9fee326a",
  "optionDetails": None,
  "status": "TRADING"
}
```

`ws.get_intraday_chart_quotes(...)`

```python
[
  {
    "__typename": "ChartBarQuote",
    "currency": "CAD",
    "marketStatus": "OPEN",
    "price": "17.1000",
    "securityId": "sec-s-6e73535b8e474d8689064c4c9fee326a",
    "sessionPrice": "17.1000",
    "timestamp": "2026-03-13T13:30:00Z"
  }
]
```

`ws.get_account_current_financials("my-wealthsimple-account-id")`

```python
{
  "__typename": "AccountCurrentFinancials",
  "id": "my-wealthsimple-account-id-CAD",
  "netLiquidationValueV2": {
    "__typename": "Money",
    "amount": "580.08505",
    "cents": 58009,
    "currency": "CAD"
  },
  "netDeposits": {
    "__typename": "Money",
    "amount": "954.22",
    "cents": 95422,
    "currency": "CAD"
  },
  "simpleReturns": {
    "__typename": "SimpleReturns",
    "amount": {
      "__typename": "Money",
      "amount": "0.00765",
      "cents": 1,
      "currency": "CAD"
    },
    "asOf": None,
    "rate": "0.000013",
    "referenceDate": "2026-03-09"
  }
}
```

`ws.get_account_graph_data("my-wealthsimple-account-id")`

```python
{
  "previousClose": {
    "__typename": "HistoricalGraphDataPoint",
    "dateTime": "2026-03-09T20:00:00.000Z",
    "netLiquidationValue": {
      "__typename": "Money",
      "amount": "580.0774",
      "currency": "CAD"
    }
  },
  "data": [
    {
      "__typename": "HistoricalGraphDataPoint",
      "dateTime": "2026-03-10T13:30:00.000Z",
      "netDeposits": {
        "__typename": "Money",
        "amount": "954.22",
        "currency": "CAD"
      },
      "netLiquidationValue": {
        "__typename": "Money",
        "amount": "580.271",
        "currency": "CAD"
      }
    }
  ]
}
```

`ws.resolve_security_id("WCP.TO")`

```python
"sec-s-ab88ccb65fe24dcc991215e07eea2e41"
```

`ws.parse_ticker_market("TSLA.US")`

```python
("TSLA", "US")
```

`ws._is_us_exchange("NASDAQ")`

```python
True
```

`ws._is_canadian_exchange("TSX")`

```python
True
```
